### PR TITLE
Fix HStack em `ButtonPuzzleView`

### DIFF
--- a/Mini2/View/ButtonPuzzleView.swift
+++ b/Mini2/View/ButtonPuzzleView.swift
@@ -148,8 +148,7 @@ class ButtonPuzzleView: UIView {
 
         view.axis         = .horizontal
         view.spacing      = 25
-        view.distribution = .fill
-        view.alignment    = .center
+        view.distribution = .fillEqually
         view.translatesAutoresizingMaskIntoConstraints = false
         
         
@@ -171,54 +170,25 @@ class ButtonPuzzleView: UIView {
     
     private func addSubviews() {
         addSubview(backgroundImage)
-//        addSubview(buttonHStackView)
+        addSubview(buttonHStackView)
 //        addSubview(successImage)
-        addSubview(firstButton)
-        addSubview(secondButton)
-        addSubview(thirdButton)
-        addSubview(fourthButton)
-        addSubview(fifthButton)
         
         addSubview(consoleImage)
         addSubview(consoleMatrix)
     }
     
     private func setupConstraints() {
-//        buttonHStackView.centerXAnchor.constraint(equalTo: centerXAnchor).setActive()
-//        buttonHStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 200).setActive()
-//        buttonHStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -200).setActive()
-//        buttonHStackView.heightAnchor.constraint(equalToConstant: 35).setActive()
-//        buttonHStackView.bottomAnchor.constraint(equalTo: bottomAnchor).setActive()
+        buttonHStackView.centerXAnchor.constraint(equalTo: centerXAnchor).setActive()
+        buttonHStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 195).setActive()
+        buttonHStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -225).setActive()
+        buttonHStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24).setActive()
+        
+        firstButton.heightAnchor.constraint(equalTo: firstButton.widthAnchor, multiplier: 15/14).setActive()
         
         backgroundImage.leadingAnchor.constraint(equalTo: leadingAnchor).setActive()
         backgroundImage.trailingAnchor.constraint(equalTo: trailingAnchor).setActive()
         backgroundImage.topAnchor.constraint(equalTo: topAnchor).setActive()
         backgroundImage.bottomAnchor.constraint(equalTo: bottomAnchor).setActive()
-        
-        firstButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 196).setActive()
-        firstButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -41).setActive()
-        firstButton.widthAnchor.constraint(equalToConstant: 48.15).setActive()
-        firstButton.heightAnchor.constraint(equalToConstant: 45).setActive()
-
-        secondButton.leadingAnchor.constraint(equalTo: firstButton.trailingAnchor, constant: 43).setActive()
-        secondButton.bottomAnchor.constraint(equalTo: firstButton.bottomAnchor).setActive()
-        secondButton.widthAnchor.constraint(equalTo: firstButton.widthAnchor).setActive()
-        secondButton.heightAnchor.constraint(equalTo: firstButton.heightAnchor).setActive()
-        
-        thirdButton.leadingAnchor.constraint(equalTo: secondButton.trailingAnchor, constant: 46).setActive()
-        thirdButton.bottomAnchor.constraint(equalTo: firstButton.bottomAnchor, constant: 3).setActive()
-        thirdButton.widthAnchor.constraint(equalTo: firstButton.widthAnchor).setActive()
-        thirdButton.heightAnchor.constraint(equalTo: firstButton.heightAnchor).setActive()
-        
-        fourthButton.leadingAnchor.constraint(equalTo: thirdButton.trailingAnchor, constant: 47).setActive()
-        fourthButton.bottomAnchor.constraint(equalTo: firstButton.bottomAnchor, constant: 3).setActive()
-        fourthButton.widthAnchor.constraint(equalTo: firstButton.widthAnchor).setActive()
-        fourthButton.heightAnchor.constraint(equalTo: firstButton.heightAnchor).setActive()
-        
-        fifthButton.leadingAnchor.constraint(equalTo: fourthButton.trailingAnchor, constant: 51).setActive()
-        fifthButton.bottomAnchor.constraint(equalTo: firstButton.bottomAnchor, constant: 3).setActive()
-        fifthButton.widthAnchor.constraint(equalTo: firstButton.widthAnchor).setActive()
-        fifthButton.heightAnchor.constraint(equalTo: firstButton.heightAnchor).setActive()
         
         consoleImage.centerXAnchor.constraint(equalTo: centerXAnchor).setActive()
         consoleImage.centerYAnchor.constraint(equalTo: centerYAnchor).setActive()


### PR DESCRIPTION
# Fix
A `ButtonPuzzleView` estava com um problema com a `HStack`. Esse PR corrige esse problema, removendo o posicionamento individual de cada botão.

## Problema
O problema que estava ocorrendo é que a imagem dos botões estava distorcendo ao tentar redimensionar ou reposicionar a `HStack`.

## Solução
A solução aplicada foi a adição de uma `constraint` em um dos botões, mais especificamente uma `constraint` de `aspectRatio` no primeiro botão. Dessa forma, ao alterar o tamanho da `HStack`, os botões irão redimensionar sua imagem de acordo com a proporção adotada (`15:14`, nesse caso).

### Evidências
![Simulator Screenshot - iPhone 14 Pro - 2023-09-07 at 12 01 00](https://github.com/JasminiSantos/Mini2/assets/118544690/18db2e1a-26d4-4e27-aabd-236c5b08b22a)

https://github.com/JasminiSantos/Mini2/assets/118544690/55e7f5fd-ed8f-451c-ac77-3d57e698fd71


